### PR TITLE
Strip metadata added to md files from Notable etc.

### DIFF
--- a/qml/python/mistune.py
+++ b/qml/python/mistune.py
@@ -27,6 +27,7 @@ _escape_pattern = re.compile(r'&(?!#?\w+;)')
 _newline_pattern = re.compile(r'\r\n|\r')
 _block_quote_leading_pattern = re.compile(r'^ *> ?', flags=re.M)
 _block_code_leading_pattern = re.compile(r'^ {4}', re.M)
+_tag_comment_pattern = re.compile(r'^---\n[\d\D\n]*\n---\n')
 _inline_tags = [
     'a', 'em', 'strong', 'small', 's', 'cite', 'q', 'dfn', 'abbr', 'data',
     'time', 'code', 'var', 'samp', 'kbd', 'sub', 'sup', 'i', 'b', 'u', 'mark',
@@ -87,6 +88,7 @@ def preprocessing(text, tab=4):
     text = _newline_pattern.sub('\n', text)
     text = text.expandtabs(tab)
     text = text.replace('\u2424', '\n')
+    text = _tag_comment_pattern.sub('', text)
     pattern = re.compile(r'^ +$', re.M)
     return pattern.sub('', text)
 


### PR DESCRIPTION
Notable creates metadata tags at the top of its files in this format: 

    ---
    tags: [Tags]
    title: Note title
    created: '2019-12-20T00:00:00.000Z'
    modified: '2020-01-20T00:00:00.000Z'
    ---

This patch removes that metadata from the rendered markdown, to allow Notizen.md interoperability with Notable. It should leave pretty much everything else unchanged, as in standard Markdown "---" would be a heading level 2 marker or horizontal rule, and would not appear on the first line.